### PR TITLE
Modernize project packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,4 +12,3 @@ exclude *.egg-info/
 
 # Include essential files
 include README.md
-include LICENSE

--- a/README.md
+++ b/README.md
@@ -10,4 +10,19 @@ The package is available on PyPi. However, currently, it's not perfect, and shou
 
 The goal of the package is to make it easier for historians to use AI in their research. It will assist in parsing texts, sending them to the OpenAI API, and viewing the results. 
 
-See the notebook for info on how to use this. 
+See the notebook for info on how to use this.
+
+## Installation
+
+The package now ships with a modern `pyproject.toml` configuration.  You can
+install it directly from the repository using:
+
+```bash
+pip install git+https://github.com/trister95/dbnl_bear.git
+```
+
+Or clone the repository and install in editable mode:
+
+```bash
+pip install -e .
+```

--- a/dbnl_bear/__init__.py
+++ b/dbnl_bear/__init__.py
@@ -1,12 +1,20 @@
+from importlib.metadata import version, PackageNotFoundError
+
 from .parse import parser
 from .ai_read import analyze_document
 from .processing import run_processing
 from .token_cost import TokenCostTracker
+
+try:
+    __version__ = version("dbnl_bear")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
 
 __all__ = [
     'parser',
     'analyze_document',
     'run_processing',
     'TokenCostTracker',
+    '__version__',
 ]
 

--- a/dbnl_bear/__main__.py
+++ b/dbnl_bear/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/dbnl_bear/overview.py
+++ b/dbnl_bear/overview.py
@@ -1,6 +1,6 @@
 import docx
 from docx.shared import RGBColor
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 import matplotlib.pyplot as plt
 import tqdm 
 
@@ -18,7 +18,7 @@ import docx
 from difflib import SequenceMatcher
 import re
 import tqdm
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 import numpy as np
 
 def highlight_relevant_passages(input_file, output_file, relevant_passages):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dbnl_bear"
+version = "0.3.3"
+description = "A Python package to use an AI assistant for historical analysis"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [
+  {name = "Arjan van Dalfsen", email = "j.a.vandalfsen@uu.nl"}
+]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Operating System :: OS Independent",
+]
+dependencies = [
+  "lxml>=4.9",
+  "tqdm>=4.66",
+  "python-dotenv>=1.0",
+  "langchain-core>=0.1",
+  "langchain-openai>=0.1",
+  "langchain-text-splitters>=0.0.5",
+  "python-docx>=0.8.11",
+  "rapidfuzz>=3.6",
+  "pydantic>=2.6"
+]
+
+[project.scripts]
+dbnl-bear = "dbnl_bear.cli:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,7 @@ langchain-text-splitters>=0.0.5
 
 # ── Document handling & fuzzy matching ───────────────────────────────────
 python-docx>=0.8.11       # read / write Word files
-fuzzywuzzy[speedup]>=0.18 # string similarity (speedup pulls in python‑Levenshtein)
-python-Levenshtein>=0.23  # explicit for when fuzzywuzzy isn't installed with [speedup]
+rapidfuzz>=3.6            # string similarity
 
 # ── Data validation ──────────────────────────────────────────────────────
 pydantic>=2.6


### PR DESCRIPTION
## Summary
- switch build to `pyproject.toml`
- add `__main__` module for `python -m dbnl_bear`
- expose package version at runtime
- replace deprecated `fuzzywuzzy` with `rapidfuzz`
- document installation instructions
- drop reference to missing LICENSE file

## Testing
- `pip install -e .` *(fails: Could not install build deps)*
- `python -m dbnl_bear --help`

------
https://chatgpt.com/codex/tasks/task_e_68820ddfba388322928804c794e3ddc2