### PR TITLE
Fix typos in README and parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![My Package Logo](assets/logo.png)
 
-This is dbnl_bear, a python package to make it easier to use AI for reading assistance in historical analaysis. 
+This is dbnl_bear, a python package to make it easier to use AI for reading assistance in historical analysis.
 
 The "bear" part of the package name is inspired by a passage from Alex Komoroske's Bits and Bobs:
 

--- a/dbnl_bear/parse.py
+++ b/dbnl_bear/parse.py
@@ -44,7 +44,7 @@ class DBNLParser:
     @staticmethod
     def extract_dbnl_id(f_name):
         """
-        Etract dbnl-id from a filename.
+        Extract dbnl-id from a filename.
         """
         pattern = r"[a-zA-Z_]{4}\d{3}[a-zA-Z_\d]{4}\d{2}"
         regex = re.compile(pattern)


### PR DESCRIPTION
## Summary
- fix typo "analaysis" in README
- fix typo "Etract" in parse module

## Testing
- `python -m py_compile dbnl_bear/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68821cb05a848322b252374165b4fb12